### PR TITLE
Fix missing header which caused compiler warning

### DIFF
--- a/source/modules/m_ble.c
+++ b/source/modules/m_ble.c
@@ -54,6 +54,7 @@
 #include "advertiser_beacon.h"
 #include "pca20020.h"
 #include "nrf_delay.h"
+#include "ant_stack_config.h"
 
 #ifdef BLE_DFU_APP_SUPPORT
     #include "ble_dfu.h"


### PR DESCRIPTION
Include ant_stack_config.h in m_ble.c so the compiler doesn't complain
about an undefined reference.

Change-Id: I65b5f324e7ff8d4a3928d0b7f2647dd2c7969848
Type: Bug Fix