### PR TITLE
Build bootloader_secure

### DIFF
--- a/include/macros/macros_common.h
+++ b/include/macros/macros_common.h
@@ -47,7 +47,6 @@
 #ifndef __MACROS_COMMON_H__
 #define __MACROS_COMMON_H__
 
-#include "SEGGER_RTT.h"
 
 /**@brief global debug flag will enable debug print from all files
  */
@@ -56,6 +55,7 @@
 #endif
 
 #ifdef LOCAL_DEBUG
+    #include "SEGGER_RTT.h"
     #define DEBUG_PRINTF    (void)SEGGER_RTT_printf
 #else
     #define DEBUG_PRINTF(...)
@@ -66,7 +66,7 @@
 #define RETURN_IF_ERROR(err_code)                                                                  \
 if ((err_code) != NRF_SUCCESS)                                                                     \
 {                                                                                                  \
-    (void)SEGGER_RTT_printf(0, RTT_CTRL_TEXT_BRIGHT_RED                                            \
+    DEBUG_PRINTF(0, RTT_CTRL_TEXT_BRIGHT_RED                                                       \
     "ERROR. Returned in file: %s, line: %d, with error code %d \r\n"RTT_CTRL_RESET,                \
     __FILE__, __LINE__, err_code);                                                                 \
     return (err_code);                                                                             \

--- a/project/bootloader_secure/pca10040/armgcc/Makefile
+++ b/project/bootloader_secure/pca10040/armgcc/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME     := secure_dfu_secure_dfu_ble_s132_pca10040
 TARGETS          := nrf52832_xxaa_s132
 OUTPUT_DIRECTORY := _build
 
-SDK_ROOT := ../../../../..
+SDK_ROOT := ../../../../external/sdk
 PROJ_DIR := ../..
 
 $(OUTPUT_DIRECTORY)/nrf52832_xxaa_s132.out: \
@@ -25,9 +25,10 @@ SRC_FILES += \
   $(SDK_ROOT)/components/drivers_nrf/common/nrf_drv_common.c \
   $(SDK_ROOT)/components/drivers_nrf/rng/nrf_drv_rng.c \
   $(SDK_ROOT)/components/drivers_nrf/hal/nrf_nvmc.c \
+  $(SDK_ROOT)/components/drivers_nrf/twi_master/nrf_drv_twi.c \
   $(SDK_ROOT)/components/libraries/bootloader/ble_dfu/nrf_ble_dfu.c \
   $(PROJ_DIR)/dfu-cc.pb.c \
-  $(PROJ_DIR)/dfu_public_key.c \
+  $(PROJ_DIR)/keys/public_key.c \
   $(PROJ_DIR)/dfu_req_handling.c \
   $(PROJ_DIR)/main.c \
   $(SDK_ROOT)/components/ble/common/ble_advdata.c \
@@ -48,21 +49,27 @@ SRC_FILES += \
   $(SDK_ROOT)/components/libraries/bootloader/dfu/nrf_dfu_settings.c \
   $(SDK_ROOT)/components/libraries/bootloader/dfu/nrf_dfu_transport.c \
   $(SDK_ROOT)/components/libraries/bootloader/dfu/nrf_dfu_utils.c \
+  $(PROJ_DIR)/../../source/drivers/drv_ext_light.c \
+  $(PROJ_DIR)/../../source/drivers/drv_sx1509.c \
+  $(PROJ_DIR)/../../source/util/sx150x_led_drv_calc.c \
+  $(PROJ_DIR)/../../source/util/twi_manager.c \
 
 # Include folders common to all targets
 INC_FOLDERS += \
-  $(PROJ_DIR)/config/secure_dfu_secure_dfu_ble_s132_pca10040 \
-  $(PROJ_DIR)/config \
   $(SDK_ROOT)/components/toolchain/cmsis/include \
-  $(PROJ_DIR)/../../bsp \
   $(SDK_ROOT)/components/drivers_nrf/rng \
   $(SDK_ROOT)/components/toolchain \
   $(SDK_ROOT)/components/device \
   $(SDK_ROOT)/components/drivers_nrf/hal \
+  $(SDK_ROOT)/components/drivers_nrf/twi_master \
   $(SDK_ROOT)/components/libraries/sha256 \
   $(SDK_ROOT)/components/libraries/crc32 \
   $(SDK_ROOT)/components/libraries/experimental_section_vars \
   $(PROJ_DIR) \
+  $(PROJ_DIR)/../../include/board \
+  $(PROJ_DIR)/../../include/drivers \
+  $(PROJ_DIR)/../../include/macros \
+  $(PROJ_DIR)/../../include/util \
   $(SDK_ROOT)/components/libraries/fstorage \
   $(SDK_ROOT)/components/libraries/util \
   $(SDK_ROOT)/components \
@@ -76,7 +83,6 @@ INC_FOLDERS += \
   $(SDK_ROOT)/components/drivers_nrf/delay \
   $(SDK_ROOT)/components/ble/common \
   $(SDK_ROOT)/components/libraries/fifo \
-  $(SDK_ROOT)/components/libraries/bootloader/ble_dfu/includes \
   $(SDK_ROOT)/components/libraries/svc \
   $(SDK_ROOT)/components/libraries/log \
   $(SDK_ROOT)/components/libraries/hci \

--- a/project/bootloader_secure/pca10040_debug/armgcc/Makefile
+++ b/project/bootloader_secure/pca10040_debug/armgcc/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME     := secure_dfu_secure_dfu_ble_s132_pca10040_debug
 TARGETS          := nrf52832_xxaa_s132
 OUTPUT_DIRECTORY := _build
 
-SDK_ROOT := ../../../../..
+SDK_ROOT := ../../../../external/sdk
 PROJ_DIR := ../..
 
 $(OUTPUT_DIRECTORY)/nrf52832_xxaa_s132.out: \
@@ -29,9 +29,10 @@ SRC_FILES += \
   $(SDK_ROOT)/components/drivers_nrf/common/nrf_drv_common.c \
   $(SDK_ROOT)/components/drivers_nrf/rng/nrf_drv_rng.c \
   $(SDK_ROOT)/components/drivers_nrf/hal/nrf_nvmc.c \
+  $(SDK_ROOT)/components/drivers_nrf/twi_master/nrf_drv_twi.c \
   $(SDK_ROOT)/components/libraries/bootloader/ble_dfu/nrf_ble_dfu.c \
   $(PROJ_DIR)/dfu-cc.pb.c \
-  $(PROJ_DIR)/dfu_public_key.c \
+  $(PROJ_DIR)/keys/public_key.c \
   $(PROJ_DIR)/dfu_req_handling.c \
   $(PROJ_DIR)/main.c \
   $(SDK_ROOT)/external/segger_rtt/RTT_Syscalls_GCC.c \
@@ -53,21 +54,27 @@ SRC_FILES += \
   $(SDK_ROOT)/components/libraries/bootloader/dfu/nrf_dfu_settings.c \
   $(SDK_ROOT)/components/libraries/bootloader/dfu/nrf_dfu_transport.c \
   $(SDK_ROOT)/components/libraries/bootloader/dfu/nrf_dfu_utils.c \
+  $(PROJ_DIR)/../../source/drivers/drv_ext_light.c \
+  $(PROJ_DIR)/../../source/drivers/drv_sx1509.c \
+  $(PROJ_DIR)/../../source/util/sx150x_led_drv_calc.c \
+  $(PROJ_DIR)/../../source/util/twi_manager.c \
 
 # Include folders common to all targets
 INC_FOLDERS += \
-  $(PROJ_DIR)/config/secure_dfu_secure_dfu_ble_s132_pca10040_debug \
-  $(PROJ_DIR)/config \
   $(SDK_ROOT)/components/toolchain/cmsis/include \
-  $(PROJ_DIR)/../../bsp \
   $(SDK_ROOT)/components/drivers_nrf/rng \
   $(SDK_ROOT)/components/toolchain \
   $(SDK_ROOT)/components/device \
   $(SDK_ROOT)/components/drivers_nrf/hal \
+  $(SDK_ROOT)/components/drivers_nrf/twi_master \
   $(SDK_ROOT)/components/libraries/sha256 \
   $(SDK_ROOT)/components/libraries/crc32 \
   $(SDK_ROOT)/components/libraries/experimental_section_vars \
   $(PROJ_DIR) \
+  $(PROJ_DIR)/../../include/board \
+  $(PROJ_DIR)/../../include/drivers \
+  $(PROJ_DIR)/../../include/macros \
+  $(PROJ_DIR)/../../include/util \
   $(SDK_ROOT)/components/libraries/fstorage \
   $(SDK_ROOT)/components/libraries/util \
   $(SDK_ROOT)/components \
@@ -81,7 +88,6 @@ INC_FOLDERS += \
   $(SDK_ROOT)/components/drivers_nrf/delay \
   $(SDK_ROOT)/components/ble/common \
   $(SDK_ROOT)/components/libraries/fifo \
-  $(SDK_ROOT)/components/libraries/bootloader/ble_dfu/includes \
   $(SDK_ROOT)/components/libraries/svc \
   $(SDK_ROOT)/components/libraries/log \
   $(SDK_ROOT)/components/libraries/hci \

--- a/project/bootloader_secure/secure_dfu_gcc_nrf52.ld
+++ b/project/bootloader_secure/secure_dfu_gcc_nrf52.ld
@@ -11,7 +11,7 @@ MEMORY
    *  those values do not match. The check is performed in main.c, see
    *  APP_ERROR_CHECK_BOOL(*((uint32_t *)NRF_UICR_BOOT_START_ADDRESS) == BOOTLOADER_REGION_START);
    */
-  FLASH (rx) : ORIGIN = 0x78000, LENGTH = 0x6000
+  FLASH (rx) : ORIGIN = 0x75000, LENGTH = 0x9000
 
   /** RAM Region for bootloader. This setting is suitable when used with s132. */
   RAM (rwx) :  ORIGIN = 0x20002C00, LENGTH = 0x5380

--- a/project/bootloader_secure/secure_dfu_gcc_nrf52_debug.ld
+++ b/project/bootloader_secure/secure_dfu_gcc_nrf52_debug.ld
@@ -11,7 +11,7 @@ MEMORY
    *  those values do not match. The check is performed in main.c, see
    *  APP_ERROR_CHECK_BOOL(*((uint32_t *)NRF_UICR_BOOT_START_ADDRESS) == BOOTLOADER_REGION_START);
    */
-  FLASH (rx) : ORIGIN = 0x75000, LENGTH = 0x9000
+  FLASH (rx) : ORIGIN = 0x73000, LENGTH = 0xB000
 
   /** RAM Region for bootloader. This setting is suitable when used with s132. */
   RAM (rwx) :  ORIGIN = 0x20002C00, LENGTH = 0x5380

--- a/source/drivers/drv_ext_gpio.c
+++ b/source/drivers/drv_ext_gpio.c
@@ -52,7 +52,7 @@ static drv_ext_gpio_init_t m_drv_ext_gpio;
 #define RETURN_IF_ERROR_EXT_GPIO_CLOSE(err_code)                                                   \
 if ((err_code) != NRF_SUCCESS)                                                                     \
 {                                                                                                  \
-    (void)SEGGER_RTT_printf(0, RTT_CTRL_TEXT_BRIGHT_RED                                            \
+    DEBUG_PRINTF(0, RTT_CTRL_TEXT_BRIGHT_RED                                                       \
     "ERROR. Returned in file: %s, line: %d, with error code %d \r\n"RTT_CTRL_RESET,                \
     __FILE__, __LINE__, err_code);                                                                 \
     (void)drv_sx1509_close();                                                                      \


### PR DESCRIPTION
The bootloader_secure project would not build. The Makefiles were missing several drivers source files and includes. Also, the linker scripts' FLASH region sizes needed to be increased. I was still getting linker errors on the function SEGGER_RTT_printf until the fix was made to macros_common.h.

Both the release and debug versions are now building successfully. I have tested these builds on the Thingy:52 by fully erasing, flashing s132_nrf52_3.0.0_softdevice.hex, and then flashing nrf52832_xxaa_s132.hex. I get the blinking yellow LED, and see it advertising as "ThingyDfu". I tested RTT printing on the debug version using SEGGER RTT Viewer.