### PR TITLE
m_batt_meas: correct interpretation of XC6804 CSO signal

### DIFF
--- a/source/modules/m_batt_meas.c
+++ b/source/modules/m_batt_meas.c
@@ -245,11 +245,11 @@ static void gpiote_evt_handler(nrf_drv_gpiote_pin_t pin, nrf_gpiote_polarity_t u
     {
         if (nrf_gpio_pin_read(m_batt_meas_param.batt_chg_stat_pin_no))
         {
-            event_source = M_BATT_MEAS_EVENT_USB_CONN_CHARGING_FINISHED;
+            event_source = M_BATT_MEAS_EVENT_USB_CONN_CHARGING;
         }
         else
         {
-            event_source = M_BATT_MEAS_EVENT_USB_CONN_CHARGING;
+            event_source = M_BATT_MEAS_EVENT_USB_CONN_CHARGING_FINISHED;
         }
     }
     else


### PR DESCRIPTION
The XC6804 charging status output pin is on during trickle and main
charging, and off when charging is complete.  The sense of the signal
was inverted in the code, resulting in a CHARGING_FINISHED event when
the USB is connected and the battery is partially discharged.  Swap the
interpretation so a CHARGING event is generated instead.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>