### PR TITLE
Fixed macro error

### DIFF
--- a/external/sdk13/external/nrf_cc310/common/integration_test_ssi_defs.h
+++ b/external/sdk13/external/nrf_cc310/common/integration_test_ssi_defs.h
@@ -1,8 +1,8 @@
 
 
-#define SHARED_SECRET_MAX_LENGHT         250
-#define ECC_KEY_MAX_LENGHT               0x256
-#define AES_KEY_MAX_LENGHT_IN_BYTES      0x10
+#define SHARED_SECRET_MAX_LENGTH         250
+#define ECC_KEY_MAX_LENGTH               0x256
+#define AES_KEY_MAX_LENGTH_IN_BYTES      0x10
 
 
 


### PR DESCRIPTION
Note that some macros are wrong, lucky is nobody uses them now,
so fixed them to avoid more errors in the future:
SHARED_SECRET_MAX_LENGHT -> SHARED_SECRET_MAX_LENGTH
ECC_KEY_MAX_LENGHT -> ECC_KEY_MAX_LENGTH
AES_KEY_MAX_LENGHT_IN_BYTES -> AES_KEY_MAX_LENGTH_IN_BYTES